### PR TITLE
docs: :pencil2: fix link under documentation in roadmap

### DIFF
--- a/roadmap.qmd
+++ b/roadmap.qmd
@@ -66,7 +66,7 @@ dissemination.
 | {{< var status.wip >}} | Ongoing | [`seedcase-project/team`](https://github.com/seedcase-project/team) | Documentation specific to the Seedcase team, like onboarding, common configuration files, and meeting agendas and minutes. |
 | {{< var status.wip >}} | Ongoing | [`seedcase-project/community`](https://github.com/seedcase-project/community) | Content for community building, outreach, and contributing guidelines for the Seedcase Project |
 | {{< var status.wip >}} | Ongoing | [`seedcase-project/seedcase-website`](https://github.com/seedcase-project/seedcase-website) | Main website for the Seedcase Project |
-| {{< var status.wip >}} | Early-to-mid 2025 | [`sprout.seedcase-project.org`](https://sprout.seedcase-project.org/guide) usage guide | Guide for using and interacting with `seedcase-sprout`. |
+| {{< var status.wip >}} | Early-to-mid 2025 | [`sprout.seedcase-project.org`](https://sprout.seedcase-project.org/docs/guide) usage guide | Guide for using and interacting with `seedcase-sprout`. |
 | {{< var status.wip >}} | Late 2025 | Flower usage guide | Guide for using and interacting with `seedcase-flower` |
 | {{< var status.wip >}} | Mid 2026 | Propagate usage guide | Guide for using and interacting with `seedcase-propagate` |
 | {{< var status.wip >}} | Late 2026 | Garden usage guide | Guide for using and interacting with `seedcase-garden` |


### PR DESCRIPTION
## Description

These changes unless we are waiting for an update to community which will remove the docs folder and move guide.qmd up a level, then this tiny fix needs to be pushed.

Missing the folder `/docs/` in the link to the sprout guide.

## Reviewer Focus

<!-- Please delete as appropriate: -->
This PR needs a quick review.

Focus on whether or not another issue is on the way removing the folder /docs, otherwise this should be a tiny fix of just one link.

## Checklist

- [x] Rendered website locally
