### PR TITLE
docs: ✏️ link to community repo instead of webpage

### DIFF
--- a/roadmap.qmd
+++ b/roadmap.qmd
@@ -155,7 +155,6 @@ products are all classified as "ongoing".
 
 | Status | Information resource |
 |----------------------------------------------|--------------------------|
-| {{< var status.ongoing >}} | [`seedcase-project/decisions`](https://github.com/seedcase-project/decisions): Archival records on the decisions made for tools or processes we use in the Seedcase Project. |
 | {{< var status.ongoing >}} | [`seedcase-project/design`](https://github.com/seedcase-project/design): Overall architectural design documentation for Seedcase software. |
 | {{< var status.ongoing >}} | [`seedcase-project/team`](https://github.com/seedcase-project/team): Documentation specific to the Seedcase team, like onboarding, common configuration files, and meeting agendas and minutes. |
 | {{< var status.ongoing >}} | [`seedcase-project/community`](https://github.com/seedcase-project/community): Content for community building, outreach, and contributing guidelines for the Seedcase Project. |
@@ -176,6 +175,7 @@ pieces, and outreach materials.
 
 | Status | Deliverable |
 |----------------------------------------------|--------------------------|
+| {{< var status.ongoing >}} | [`seedcase-project/decisions`](https://github.com/seedcase-project/decisions): Archival records on the decisions made for tools or processes we use in the Seedcase Project. |
 | {{< var status.ongoing >}} | Knowledge sharing via the [Community](https://community.seedcase-project.org/) website: Knowledge and skills learned from attending conferences and workshops in research software and data engineering or operational management |
 | {{< var status.potential >}} | Research data engineering: What is it and why is it vital for modern research? |
 | {{< var status.potential >}} | Challenges and barriers: Workflows and digital infrastructure for building software in a team-based research environment. |

--- a/roadmap.qmd
+++ b/roadmap.qmd
@@ -176,7 +176,7 @@ pieces, and outreach materials.
 | Status | Deliverable |
 |----------------------------------------------|--------------------------|
 | {{< var status.ongoing >}} | [`seedcase-project/decisions`](https://github.com/seedcase-project/decisions): Archival records on the decisions made for tools or processes we use in the Seedcase Project. |
-| {{< var status.ongoing >}} | [`seedcase-project/community](https://community.seedcase-project.org/): Sharing knowledge and skills learned from attending conferences and workshops in research software and data engineering or operational management |
+| {{< var status.ongoing >}} | [`seedcase-project/community`](https://github.com/seedcase-project/community): Sharing knowledge and skills learned from attending conferences and workshops in research software and data engineering or operational management |
 | {{< var status.potential >}} | Research data engineering: What is it and why is it vital for modern research? |
 | {{< var status.potential >}} | Challenges and barriers: Workflows and digital infrastructure for building software in a team-based research environment. |
 

--- a/roadmap.qmd
+++ b/roadmap.qmd
@@ -176,7 +176,7 @@ pieces, and outreach materials.
 | Status | Deliverable |
 |----------------------------------------------|--------------------------|
 | {{< var status.ongoing >}} | [`seedcase-project/decisions`](https://github.com/seedcase-project/decisions): Archival records on the decisions made for tools or processes we use in the Seedcase Project. |
-| {{< var status.ongoing >}} | Knowledge sharing via the [Community](https://community.seedcase-project.org/) website: Knowledge and skills learned from attending conferences and workshops in research software and data engineering or operational management |
+| {{< var status.ongoing >}} | [`seedcase-project/community](https://community.seedcase-project.org/): Sharing knowledge and skills learned from attending conferences and workshops in research software and data engineering or operational management |
 | {{< var status.potential >}} | Research data engineering: What is it and why is it vital for modern research? |
 | {{< var status.potential >}} | Challenges and barriers: Workflows and digital infrastructure for building software in a team-based research environment. |
 


### PR DESCRIPTION
## Description

The other links in the table refer to the repos and not the repo websites, so this way it's aligned.
Alternatively, we should link to the websites instead. As long as it's aligned across tables and rows in the roadmap, I don't have any strong opinions on this :)

(This is a stacked PR on #70 to avoid merge conflicts)

## Reviewer Focus

<!-- Please delete as appropriate: -->
This PR needs a quick review.

## Checklist

- [X] Rendered website locally
