### PR TITLE
docs: 📝 split software and software-related products to 2 tables

### DIFF
--- a/roadmap.qmd
+++ b/roadmap.qmd
@@ -155,7 +155,6 @@ products are all classified as "ongoing".
 
 | Status | Information resource |
 |----------------------------------------------|--------------------------|
-| {{< var status.ongoing >}} | [`seedcase-project/decisions`](https://github.com/seedcase-project/decisions): Archival records on the decisions made for tools or processes we use in the Seedcase Project. |
 | {{< var status.ongoing >}} | [`seedcase-project/design`](https://github.com/seedcase-project/design): Overall architectural design documentation for Seedcase software. |
 | {{< var status.ongoing >}} | [`seedcase-project/team`](https://github.com/seedcase-project/team): Documentation specific to the Seedcase team, like onboarding, common configuration files, and meeting agendas and minutes. |
 | {{< var status.ongoing >}} | [`seedcase-project/community`](https://github.com/seedcase-project/community): Content for community building, outreach, and contributing guidelines for the Seedcase Project. |
@@ -176,6 +175,7 @@ pieces, and outreach materials.
 
 | Status | Deliverable |
 |----------------------------------------------|--------------------------|
+| {{< var status.ongoing >}} | [`seedcase-project/decisions`](https://github.com/seedcase-project/decisions): Archival records on the decisions made for tools or processes we use in the Seedcase Project. |
 | {{< var status.ongoing >}} | Knowledge sharing via the [Community](https://community.seedcase-project.org/) website: Knowledge and skills learned from attending conferences and workshops in research software and data engineering or operational management |
 | {{< var status.potential >}} | Research data engineering: What is it and why is it vital for modern research? |
 | {{< var status.potential >}} | Challenges and barriers: Workflows and digital infrastructure for building software in a team-based research environment. |

--- a/roadmap.qmd
+++ b/roadmap.qmd
@@ -65,20 +65,32 @@ Some of these products are not strictly software, but can be used within
 a software environment, can be integrate into other workflows, or are
 used to support research software and data engineering.
 
-| Status | Software or software-related product |
-|------------------------------------------------|-------------------------|
+::: panel-tabset
+#### Software
+
+| Status | Software |
+|-----------------------------------------------|-------------------------|
 | {{< var status.wip >}} | [`seedcase-project/seedcase-sprout`](https://github.com/seedcase-project/seedcase-sprout): Upload your research data to formally structure it for better, more reliable, and easier research. |
-| {{< var status.ongoing >}} | [`seedcase-project/seedcase-theme`](https://github.com/seedcase-project/seedcase-theme): Template repository for website projects with a Seedcase-specific Quarto extension for aesthetics, helper commands, and infrastructural files. |
-| {{< var status.ongoing >}} | [`seedcase-project/template-python-project`](https://github.com/seedcase-project/template-python-project): A template repository to use when making a Python project for Seedcase. |
-| {{< var status.ongoing >}} | [`seedcase-project/spaid`](https://github.com/seedcase-project/spaid): A toolkit for developing Seedcase projects. |
 | {{< var status.planned >}} | `seedcase-project/check-datapackage`: Check the correctness of a `datapackage.json` file. |
 | {{< var status.planned >}} | `seedcase-flower`: Cataloging and browsing metadata within a data package. |
 | {{< var status.planned >}} | `seedcase-propagate`: Submitting requests for accessing specific data from a data package. |
 | {{< var status.planned >}} | `seedcase-garden`: Tend to and track projects using data from a data package. |
 | {{< var status.potential >}} | `seedcase-sprout-extensions`: Extensions to Seedcase Sprout for common data processing or enriching tasks. |
 
+: "Wishlist" of software products we are currently working on, will work
+on, or hope to work on.
+
+#### Software-related products
+
+| Status | Software-related product |
+|-----------------------------------------------|-------------------------|
+| {{< var status.ongoing >}} | [`seedcase-project/seedcase-theme`](https://github.com/seedcase-project/seedcase-theme): Template repository for website projects with a Seedcase-specific Quarto extension for aesthetics, helper commands, and infrastructural files. |
+| {{< var status.ongoing >}} | [`seedcase-project/template-python-project`](https://github.com/seedcase-project/template-python-project): A template repository to use when making a Python project for Seedcase. |
+| {{< var status.ongoing >}} | [`seedcase-project/spaid`](https://github.com/seedcase-project/spaid): A toolkit for developing Seedcase projects. |
+
 : "Wishlist" of software-related products we are currently working on,
 will work on, or hope to work on.
+:::
 
 ### Technical documentation
 

--- a/roadmap.qmd
+++ b/roadmap.qmd
@@ -176,7 +176,7 @@ pieces, and outreach materials.
 | Status | Deliverable |
 |----------------------------------------------|--------------------------|
 | {{< var status.ongoing >}} | [`seedcase-project/decisions`](https://github.com/seedcase-project/decisions): Archival records on the decisions made for tools or processes we use in the Seedcase Project. |
-| {{< var status.ongoing >}} | Knowledge sharing via the [Community](https://community.seedcase-project.org/) website: Knowledge and skills learned from attending conferences and workshops in research software and data engineering or operational management |
+| {{< var status.ongoing >}} | [`seedcase-project/community](https://community.seedcase-project.org/): Sharing knowledge and skills learned from attending conferences and workshops in research software and data engineering or operational management |
 | {{< var status.potential >}} | Research data engineering: What is it and why is it vital for modern research? |
 | {{< var status.potential >}} | Challenges and barriers: Workflows and digital infrastructure for building software in a team-based research environment. |
 


### PR DESCRIPTION
## Description

To keep the tables "shorter" and less overwhelming to look at. We're also using panels in to split up the documentation, so why not? :) 

(Stacked PR on #71 to avoid merge conflicts)

## Reviewer Focus

<!-- Please delete as appropriate: -->
This PR needs a quick review.

Focus on CHANGES.

## Checklist

- [X] Ran spell-check
- [X] Formatted Markdown
- [X] Rendered website locally
