### PR TITLE
style: :lipstick: change status icon colours

### DIFF
--- a/_variables.yml
+++ b/_variables.yml
@@ -1,6 +1,6 @@
 status:
-    done: '[{{< fa circle-check size="xl" title="Completed an MVP" >}}]{style="color: #196440"} *Completed*'
-    wip: '[{{< fa hammer size="xl" title="In progress" >}}]{style="color: #28a167"} *In progress*'
-    planned: '[{{< fa map size="xl" title="Planned" >}}]{style="color: #45d18e"} *Planned*'
-    potential: '[{{< fa circle-question size="xl" title="Potential" >}}]{style="color: lightgrey"} *Potential*'
-    ongoing: '[{{< fa repeat size="xl" title="Ongoing" >}}]{style="color: #196440"} *Ongoing*'
+    done: '[{{< fa circle-check size="xl" title="Completed an MVP" >}}]{style="color: #48DC76"} *Completed*'
+    wip: '[{{< fa hammer size="xl" title="In progress" >}}]{style="color: #32A255"} *In progress*'
+    planned: '[{{< fa map size="xl" title="Planned" >}}]{style="color: #ADADAD"} *Planned*'
+    potential: '[{{< fa circle-question size="xl" title="Potential" >}}]{style="color: #D6D6D6"} *Potential*'
+    ongoing: '[{{< fa repeat size="xl" title="Ongoing" >}}]{style="color: #32A255"} *Ongoing*'


### PR DESCRIPTION
## Description

So "done" is the lightest green, "in progress" is darker", and both "planned" and "potential" are grey. I think this shows more clearly what we are currently working on (green nuances) and what are in the future (grey). These colours also come from the colour scale we got from Mjølner.

### Before 
![image](https://github.com/user-attachments/assets/2e86e2ca-759c-4197-911c-5564c9329a92)


### Now 
![image](https://github.com/user-attachments/assets/757df974-de93-4d58-b0f6-f944d0d87bd0)


Closes #

## Reviewer Focus

<!-- Please delete as appropriate: -->
This PR needs an in-depth review.

## Checklist

- [X] Rendered website locally
