### PR TITLE
fix: :lipstick: navbar was different because we need to use our theme's html format

### DIFF
--- a/roadmap.qmd
+++ b/roadmap.qmd
@@ -1,7 +1,7 @@
 ---
 title: Roadmap
 format:
-    html:
+    seedcase-theme-html:
         tbl-colwidths: [20, 80]
 ---
 


### PR DESCRIPTION
## Description

@signekb found that the navbar was different on the roadmap page. It seems to be because the `format: html` in the YAML needed to use our theme's HTML format.

<!-- Please delete as appropriate: -->
This PR needs a quick review.

## Checklist

- [x] Rendered website locally
