### PR TITLE
fix: :pencil2: correct typos

### DIFF
--- a/.typos.toml
+++ b/.typos.toml
@@ -1,7 +1,12 @@
 [files]
 extend-exclude = [
   "*.css",
+  "*.svg",
   ".quarto/*",
   "_site/*",
 ]
+
+[default.extend-words]
+# Trusted research environment
+TRE = "TRE"
 

--- a/learn/shorts/python-packaging-basics.qmd
+++ b/learn/shorts/python-packaging-basics.qmd
@@ -166,14 +166,14 @@ folder. Check that you are in the folder by running:
 pwd
 ```
 
-Which stands for **p**rint **w**orking **d**irectory. If it is not in
+Which stands for print working directory. If it is not in
 the package folder, use this Terminal command to move into it:
 
 ``` {.bash filename="Terminal"}
 cd ~/Desktop/packagename
 ```
 
-The `cd` command stands for **c**hange **d**irectory. You will need to
+The `cd` command stands for change directory. You will need to
 replace `packagename` with the name you called your package. Once in the
 package directory, you can install the package by running:
 

--- a/posts/fair-impact-roadshow-dk/index.qmd
+++ b/posts/fair-impact-roadshow-dk/index.qmd
@@ -113,7 +113,7 @@ good comments particularly on the challenges, such as:
     and professionals managing the research data.
 -   The limited resources (time and funds) and of skilled personnel.
     Often researchers will seek out or ask for advice or support for
-    their own work, which takes away the personnels' time for working
+    their own work, which takes away the person's time for working
     the improving things and working on their own projects.
 -   The lack of higher level visionary strategies to solve these issues.
     There's a big gap between what is talked about at the policy level

--- a/posts/lessons-learned-software-consultants/index.qmd
+++ b/posts/lessons-learned-software-consultants/index.qmd
@@ -117,4 +117,4 @@ consultants again, I would want us to do a few things differently:
     which was too long. We should have hired them for 2-3 months.
 -   Hire them to help us design rather than build a solution, something
     that is as simple as possible and that considers our constraints
-    ands our needs.
+    and our needs.

--- a/posts/research-ops-conference-2023/index.qmd
+++ b/posts/research-ops-conference-2023/index.qmd
@@ -99,7 +99,7 @@ resistance or lack of understanding from others. Her main points were:
         of work on a specific set of tasks.
     -   Use a [Kanban board](https://en.wikipedia.org/wiki/Kanban_board)
         to put work up and show what's in progress and what's done,
-        availabe in tools like
+        available in tools like
         [JIRA](https://www.atlassian.com/software/jira) or [GitHub
         Projects](https://docs.github.com/en/issues/planning-and-tracking-with-projects/learning-about-projects/about-projects).
     -   Using the Kanban board, limit the amount of items in the "work


### PR DESCRIPTION
## Description

Adding typos to the Ci triggered a build error. So fixed the issues.

No review needed.

## Checklist

- [x] Formatted Markdown
- [x] Ran `just run-all`
