### PR TITLE
fix: :bug: exclude functional programming slides from post list

### DIFF
--- a/posts/functional-programming-talk-2025/slides.qmd
+++ b/posts/functional-programming-talk-2025/slides.qmd
@@ -3,9 +3,7 @@ title: "A structured approach to writing code for software and analyses"
 author:
   - "Luke Johnston"
 date: "2025-10-23"
-categories:
-  - presentation
-  - learning
+exclude-from-listing: true
 format:
     revealjs:
         theme:


### PR DESCRIPTION
# Description

The slides shouldn't be included in the listing.

No review needed.

## Checklist

- [x] Ran `just run-all`
