### PR TITLE
fix: :lipstick: small fixes to formatting of Parquet slides

### DIFF
--- a/posts/parquet-dst-2025/slides.qmd
+++ b/posts/parquet-dst-2025/slides.qmd
@@ -12,7 +12,7 @@ format:
         slide-number: true
 ---
 
-# Outline for this presentation {.center}
+# Outline {.center}
 
 1.  Refresher: How Denmark Statistics currently stores data.
 
@@ -85,9 +85,7 @@ E.g. Stata will create `.dta` files, doubling storage needs.
 
 # Parquet file format {.center}
 
-::: aside
 <https://parquet.apache.org/>
-:::
 
 ## Parquet is a column-based data storage format {.center}
 
@@ -134,7 +132,7 @@ age,30{2},25,32,31,40,39,50
 diabetes,0,1,0{2},1,0{3}
 ```
 
-### Loading
+## Loading data is faster {.center}
 
 -   Computers read by lines.
 -   Per line = same data type.

--- a/posts/parquet-dst-2025/theme.scss
+++ b/posts/parquet-dst-2025/theme.scss
@@ -1,6 +1,6 @@
 /*-- scss:defaults --*/
 
-$presentation-font-size-root: 48px !default;
+$presentation-font-size-root: 38px !default;
 $presentation-h1-font-size: 2em !default;
 $presentation-h2-font-size: 1.5em !default;
 $code-block-font-size: 0.85em !default;


### PR DESCRIPTION
# Description

The slide font was too big, and some slides should have been split into two rather than one.

This PR needs a quick review.

## Checklist

- [x] Formatted Markdown
- [x] Ran `just run-all`
