### PR TITLE
fix: :lipstick: set subgraph background to white for FP slides

### DIFF
--- a/posts/functional-programming-talk-2025/slides.qmd
+++ b/posts/functional-programming-talk-2025/slides.qmd
@@ -771,8 +771,10 @@ graph LR
       B(Type B)
     end
 
-    M -->|M f| Out(Type A)
+    M::monad -->|M f| Out(Type A)
     A -->|f| Out
+
+    classDef monad fill:white;
 ```
 
 ## Example monad: Option type in Rust {.center}


### PR DESCRIPTION
# Description

This should have been white. Default is like a gray-ish colour.

This PR needs a quick review.

## Checklist

- [x] Formatted Markdown
- [x] Ran `just run-all`
